### PR TITLE
Add labels support in runner startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# ci-runner
+# CI Runner
+
+Контейнер для запуска собственного GitHub Actions Runner.
+
+## Запуск
+
+1. Получите токен регистрации в настройках Self-hosted Runner на GitHub.
+2. Определите переменные окружения:
+   Создайте файл `.env` рядом с `docker-compose.yml` и добавьте переменные окружения:
+
+   ```env
+   RUNNER_URL=https://github.com/owner/repo
+   RUNNER_TOKEN=XXXXXXXXXXXXXXXXX
+   RUNNER_NAME=my-runner
+   LABELS=linux,x64
+   ```
+
+   `docker-compose` автоматически подхватит значения из `.env`.
+
+3. Соберите и запустите контейнер:
+
+   ```bash
+   docker-compose up -d --build
+   ```
+
+Контейнер автоматически зарегистрирует раннер и начнёт ожидать задания.
+
+## Переменные окружения
+
+Перечисленные переменные можно задавать через `export` либо в файле `.env`.
+
+* `RUNNER_URL` — URL репозитория или организации.
+* `RUNNER_TOKEN` — токен регистрации.
+* `RUNNER_NAME` — имя раннера (по умолчанию `docker-runner`).
+* `LABELS` — дополнительные метки (опционально).
+
+## Остановка
+
+Чтобы остановить и удалить контейнер, выполните:
+
+```bash
+docker-compose down
+```

--- a/start.sh
+++ b/start.sh
@@ -7,13 +7,20 @@ if [ -z "${RUNNER_URL}" ] || [ -z "${RUNNER_TOKEN}" ]; then
 fi
 
 if [ ! -f .runner ]; then
-  ./config.sh \
-    --url "${RUNNER_URL}" \
-    --token "${RUNNER_TOKEN}" \
-    --name "${RUNNER_NAME:-docker-runner}" \
-    --work _work \
-    --unattended \
+  config_args=(
+    --url "${RUNNER_URL}"
+    --token "${RUNNER_TOKEN}"
+    --name "${RUNNER_NAME:-docker-runner}"
+    --work _work
+    --unattended
     --replace
+  )
+
+  if [ -n "${LABELS}" ]; then
+    config_args+=(--labels "${LABELS}")
+  fi
+
+  ./config.sh "${config_args[@]}"
 fi
 
 exec ./run.sh


### PR DESCRIPTION
## Summary
- propagate LABELS env var to GitHub runner config

## Testing
- `bash -n start.sh`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68987f6434848326b6f5dadfe2e9d648